### PR TITLE
refactor: update action for improved API URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@
     target-github-token: ${{ secrets.TARGET_GITHUB_TOKEN }}
     overwrite-repo-visibility: true # overwrite repo visibility with what is in yml file; defaults to false
     force-push: false # force push to target repos (overwrites history); defaults to false
-    ### these parameters are only needed if either your source or target is NOT github.com
-    # source-github-url: ${{ github.server_url }} # defaults to https://github.com
-    # source-github-api-url: ${{ github.api_url }} # defaults to https://api.github.com
-    # target-github-url: ${{ github.server_url }} # defaults to https://github.com
-    # target-github-api-url: ${{ github.api_url }} # defaults to https://api.github.com  
+    ### only needed if either your source or target is NOT github.com
+    # target-github-api-url: https://ghes.domain.com/api/v3 # API URL for GHES
+    # source-github-api-url: https://api.github.com # only needed if source is not github.com
 ```
 
 ## Repository List Format
@@ -85,6 +83,7 @@ You can use a personal access token, but it is recommended to use GitHub Apps in
           target-github-token: ${{ steps.target-app-token.outputs.token }}
           overwrite-repo-visibility: true # overwrite repo visibility with what is in yml file; defaults to false
           # force push to target repos (overwrites history); defaults to false
+          # target-github-api-url: https://ghes.domain.com/api/v3 # only needed if target is GHES
 ```
 
 ## Configuration Options
@@ -103,13 +102,11 @@ You can use a personal access token, but it is recommended to use GitHub Apps in
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `repo-list-file` | YML file with repository configurations | No | - |
+| `repo-list-file` | YML file with repository configurations | Yes | - |
 | `source-github-token` | GitHub PAT for source repositories | Yes | - |
 | `target-github-token` | GitHub PAT for target repositories | No | (uses source token if not specified) |
-| `source-github-url` | Source GitHub server URL | No | `${{ github.server_url }}` |
-| `target-github-url` | Target GitHub server URL | No | `${{ github.server_url }}` |
-| `source-github-api-url` | Source GitHub API URL | No | `${{ github.api_url }}` |
-| `target-github-api-url` | Target GitHub API URL | No | `${{ github.api_url }}` |
+| `source-github-api-url` | Source GitHub API URL (e.g., `https://api.github.com` or `https://ghes.domain.com/api/v3`). Instance URL is auto-derived. | No | `${{ github.api_url }}` |
+| `target-github-api-url` | Target GitHub API URL (e.g., `https://api.github.com` or `https://ghes.domain.com/api/v3`). Instance URL is auto-derived. | No | `${{ github.api_url }}` |
 | `overwrite-repo-visibility` | Force update visibility of existing repos | No | `false` |
 | `force-push` | Force push to target repositories (overwrites history) | No | `false` |
 

--- a/action.yml
+++ b/action.yml
@@ -15,20 +15,12 @@ inputs:
   target-github-token:
     description: "GitHub Personal Access Token for creating/updating target repositories"
     required: false
-  source-github-url:
-    description: "Source GitHub server URL  (for GitHub Enterprise Server, usually like https://ghes.domain.com)"
-    required: false
-    default: "${{ github.server_url }}"
   source-github-api-url:
-    description: "Source GitHub API URL (for GitHub Enterprise Server, usually like: https://ghes.domain.com/api/v3)"
+    description: "Source GitHub API URL (e.g., https://api.github.com for GitHub.com or https://ghes.domain.com/api/v3 for GHES). Instance URL is auto-derived."
     required: false
     default: "${{ github.api_url }}"
-  target-github-url:
-    description: "Target GitHub server URL (for GitHub Enterprise Server, usually like https://ghes.domain.com)"
-    required: false
-    default: "${{ github.server_url }}"
   target-github-api-url:
-    description: "Target GitHub API URL (for GitHub Enterprise Server, usually like: https://ghes.domain.com/api/v3)"
+    description: "Target GitHub API URL (e.g., https://api.github.com for GitHub.com or https://ghes.domain.com/api/v3 for GHES). Instance URL is auto-derived."
     required: false
     default: "${{ github.api_url }}"
   overwrite-repo-visibility:


### PR DESCRIPTION
and remove unnecessary parameters

**Configuration simplification:**
- Removed all references to `source-github-url` and `target-github-url` from code, documentation, and input definitions. Now, only API URLs are required, and the instance/server URL is auto-derived from the API URL. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L49-R49) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L84-L93) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L18-R23) [[4]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L153-R186) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R32)
- Added a helper function `deriveInstanceUrl` in `src/index.js` to automatically compute the instance URL from the provided API URL for both source and target. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R109-R131) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L153-R186)

**Documentation and input updates:**
- Updated `README.md` and `action.yml` to clarify usage of API URLs, provide more accurate examples, and indicate that the repo list file (`repo-list-file`) is now a required input. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R109) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L18-R23)
- Updated CLI help, examples, and environment variable documentation in `src/index.js` to remove references to server URLs and use only API URLs. [[1]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L14-L15) [[2]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L38-R37) [[3]](diffhunk://#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556L49-R49)

**Input requirements:**
- Changed the `repo-list-file` input from optional to required in both the documentation and the action definition. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R109) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L18-R23)